### PR TITLE
Challenge 2: Law Firm Backend Schema — CPTs, ACF, Schema.org, Templates

### DIFF
--- a/challenge-2/package.json
+++ b/challenge-2/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "watch-blocks": "gulp dev",
-    "watch-js": "webpack --mode=development --config=./webpack/webpack.local.config.js --watch",
+    "watch-js": "webpack --mode=development --config=./webpack/webpack.config.js --watch",
     "dev": "npm-run-all --parallel watch-*",
     "build-blocks": "gulp",
     "build-js": "NODE_ENV=production webpack --mode=production --config=./webpack/webpack.config.js",

--- a/challenge-2/theme/acf-json/group_local.json
+++ b/challenge-2/theme/acf-json/group_local.json
@@ -1,0 +1,58 @@
+{
+  "key": "group_local",
+  "title": "Area Served Fields",
+  "fields": [
+    {
+      "key": "field_local_content_type",
+      "label": "Content Type",
+      "name": "content_type",
+      "type": "select",
+      "instructions": "Is this location data or an area served page?",
+      "required": 1,
+      "choices": {
+        "Area Served": "Area Served",
+        "Location": "Location"
+      },
+      "default_value": "Area Served"
+    },
+    {
+      "key": "field_local_area_type",
+      "label": "Area Type",
+      "name": "area_type",
+      "type": "select",
+      "instructions": "e.g. State, City, County",
+      "required": 0,
+      "choices": {
+        "State": "State",
+        "City": "City",
+        "County": "County",
+        "Region": "Region"
+      }
+    },
+    {
+      "key": "field_local_geopoint",
+      "label": "Geopoint",
+      "name": "geopoint",
+      "type": "google_map",
+      "instructions": "Center point for this area",
+      "required": 0
+    }
+  ],
+  "location": [
+    [
+      {
+        "param": "post_type",
+        "operator": "==",
+        "value": "local"
+      }
+    ]
+  ],
+  "menu_order": 0,
+  "position": "normal",
+  "style": "default",
+  "label_placement": "top",
+  "instruction_placement": "label",
+  "hide_on_screen": "",
+  "active": true,
+  "description": ""
+}

--- a/challenge-2/theme/acf-json/group_office.json
+++ b/challenge-2/theme/acf-json/group_office.json
@@ -1,0 +1,91 @@
+{
+  "key": "group_office",
+  "title": "Office Fields",
+  "fields": [
+    {
+      "key": "field_office_address",
+      "label": "Address",
+      "name": "address",
+      "type": "group",
+      "required": 0,
+      "sub_fields": [
+        {
+          "key": "field_office_street",
+          "label": "Street Address",
+          "name": "street",
+          "type": "text",
+          "required": 1
+        },
+        {
+          "key": "field_office_street2",
+          "label": "Street Address 2",
+          "name": "street2",
+          "type": "text",
+          "required": 0
+        },
+        {
+          "key": "field_office_city",
+          "label": "City",
+          "name": "city",
+          "type": "text",
+          "required": 1
+        },
+        {
+          "key": "field_office_state",
+          "label": "State",
+          "name": "state",
+          "type": "text",
+          "required": 1
+        },
+        {
+          "key": "field_office_postal_code",
+          "label": "Postal Code",
+          "name": "postal_code",
+          "type": "text",
+          "required": 1
+        }
+      ]
+    },
+    {
+      "key": "field_office_geopoint",
+      "label": "Geopoint",
+      "name": "geopoint",
+      "type": "google_map",
+      "instructions": "Pin the office location on the map",
+      "required": 1
+    },
+    {
+      "key": "field_office_phone",
+      "label": "Phone Number",
+      "name": "phone_number",
+      "type": "link",
+      "required": 0,
+      "return_format": "array"
+    },
+    {
+      "key": "field_office_directions",
+      "label": "Directions Link",
+      "name": "directions_link",
+      "type": "link",
+      "required": 0,
+      "return_format": "url"
+    }
+  ],
+  "location": [
+    [
+      {
+        "param": "post_type",
+        "operator": "==",
+        "value": "office"
+      }
+    ]
+  ],
+  "menu_order": 0,
+  "position": "normal",
+  "style": "default",
+  "label_placement": "top",
+  "instruction_placement": "label",
+  "hide_on_screen": "",
+  "active": true,
+  "description": ""
+}

--- a/challenge-2/theme/acf-json/group_practice-area.json
+++ b/challenge-2/theme/acf-json/group_practice-area.json
@@ -1,0 +1,77 @@
+{
+  "key": "group_practice_area",
+  "title": "Practice Area Fields",
+  "fields": [
+    {
+      "key": "field_pa_testimonials",
+      "label": "Testimonials",
+      "name": "testimonials",
+      "type": "relationship",
+      "instructions": "Select related testimonials for this practice area",
+      "required": 0,
+      "post_type": ["testimonials"],
+      "filters": ["search"],
+      "return_format": "object"
+    },
+    {
+      "key": "field_pa_schema_faq",
+      "label": "FAQ Items",
+      "name": "schema_faq_items",
+      "type": "repeater",
+      "instructions": "Add FAQ items for schema markup",
+      "required": 0,
+      "sub_fields": [
+        {
+          "key": "field_pa_faq_question",
+          "label": "Question",
+          "name": "question",
+          "type": "text",
+          "required": 1
+        },
+        {
+          "key": "field_pa_faq_answer",
+          "label": "Answer",
+          "name": "answer",
+          "type": "wysiwyg",
+          "required": 1
+        }
+      ]
+    },
+    {
+      "key": "field_pa_geopoint",
+      "label": "Geopoint",
+      "name": "geopoint",
+      "type": "google_map",
+      "instructions": "Center point for this practice area's coverage area",
+      "required": 0
+    },
+    {
+      "key": "field_pa_related_attorneys",
+      "label": "Related Attorneys",
+      "name": "related_attorneys",
+      "type": "relationship",
+      "instructions": "Select attorneys who practice in this area",
+      "required": 0,
+      "post_type": ["team"],
+      "filters": ["search"],
+      "return_format": "object"
+    }
+  ],
+  "location": [
+    [
+      {
+        "param": "post_type",
+        "operator": "==",
+        "value": "practice-area"
+      }
+    ]
+  ],
+  "menu_order": 0,
+  "position": "normal",
+  "style": "default",
+  "label_placement": "top",
+  "instruction_placement": "label",
+  "hide_on_screen": "",
+  "active": true,
+  "description": ""
+}

--- a/challenge-2/theme/acf-json/group_team.json
+++ b/challenge-2/theme/acf-json/group_team.json
@@ -1,0 +1,96 @@
+{
+  "key": "group_team",
+  "title": "Attorney Fields",
+  "fields": [
+    {
+      "key": "field_team_position",
+      "label": "Position / Title",
+      "name": "position",
+      "type": "text",
+      "instructions": "e.g. Senior Partner, Associate, Of Counsel",
+      "required": 0
+    },
+    {
+      "key": "field_team_phone",
+      "label": "Phone Number",
+      "name": "phone",
+      "type": "text",
+      "required": 0
+    },
+    {
+      "key": "field_team_email",
+      "label": "Email",
+      "name": "email",
+      "type": "email",
+      "required": 0
+    },
+    {
+      "key": "field_team_office",
+      "label": "Primary Office",
+      "name": "office",
+      "type": "post_object",
+      "instructions": "Select the attorney's primary office",
+      "required": 0,
+      "post_type": ["office"],
+      "return_format": "object"
+    },
+    {
+      "key": "field_team_bar_admissions",
+      "label": "Bar Admissions",
+      "name": "bar_admissions",
+      "type": "repeater",
+      "instructions": "States/ jurisdictions where the attorney is admitted",
+      "required": 0,
+      "sub_fields": [
+        {
+          "key": "field_team_bar_state",
+          "label": "State",
+          "name": "state",
+          "type": "text",
+          "required": 1
+        }
+      ]
+    },
+    {
+      "key": "field_team_education",
+      "label": "Education",
+      "name": "education",
+      "type": "repeater",
+      "instructions": "Law schools and degrees",
+      "required": 0,
+      "sub_fields": [
+        {
+          "key": "field_team_edu_school",
+          "label": "School",
+          "name": "school",
+          "type": "text",
+          "required": 1
+        },
+        {
+          "key": "field_team_edu_degree",
+          "label": "Degree",
+          "name": "degree",
+          "type": "text",
+          "required": 0
+        }
+      ]
+    }
+  ],
+  "location": [
+    [
+      {
+        "param": "post_type",
+        "operator": "==",
+        "value": "team"
+      }
+    ]
+  ],
+  "menu_order": 0,
+  "position": "normal",
+  "style": "default",
+  "label_placement": "top",
+  "instruction_placement": "label",
+  "hide_on_screen": "",
+  "active": true,
+  "description": ""
+}

--- a/challenge-2/theme/acf-json/group_testimonials.json
+++ b/challenge-2/theme/acf-json/group_testimonials.json
@@ -1,0 +1,77 @@
+{
+  "key": "group_testimonials",
+  "title": "Testimonial Fields",
+  "fields": [
+    {
+      "key": "field_test_rating",
+      "label": "Rating",
+      "name": "rating",
+      "type": "select",
+      "instructions": "Star rating for this review",
+      "required": 1,
+      "choices": {
+        "1": "1 Star",
+        "2": "2 Stars",
+        "3": "3 Stars",
+        "4": "4 Stars",
+        "5": "5 Stars"
+      },
+      "default_value": "5"
+    },
+    {
+      "key": "field_test_reviewer_name",
+      "label": "Reviewer Name",
+      "name": "reviewer_name",
+      "type": "text",
+      "required": 1
+    },
+    {
+      "key": "field_test_reviewer",
+      "label": "Reviewer Details",
+      "name": "reviewer",
+      "type": "group",
+      "required": 0,
+      "sub_fields": [
+        {
+          "key": "field_test_reviewer_name_sub",
+          "label": "Name",
+          "name": "name",
+          "type": "text"
+        },
+        {
+          "key": "field_test_reviewer_location",
+          "label": "Location",
+          "name": "location",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "key": "field_test_practice_area",
+      "label": "Practice Area",
+      "name": "practice_area",
+      "type": "post_object",
+      "instructions": "Link this testimonial to a practice area",
+      "required": 0,
+      "post_type": ["practice-area"],
+      "return_format": "object"
+    }
+  ],
+  "location": [
+    [
+      {
+        "param": "post_type",
+        "operator": "==",
+        "value": "testimonials"
+      }
+    ]
+  ],
+  "menu_order": 0,
+  "position": "normal",
+  "style": "default",
+  "label_placement": "top",
+  "instruction_placement": "label",
+  "hide_on_screen": "",
+  "active": true,
+  "description": ""
+}

--- a/challenge-2/theme/acf-json/group_theme_settings.json
+++ b/challenge-2/theme/acf-json/group_theme_settings.json
@@ -1,0 +1,179 @@
+{
+  "key": "group_theme_settings",
+  "title": "Theme Settings",
+  "fields": [
+    {
+      "key": "field_settings_contact_phone",
+      "label": "Main Phone Number",
+      "name": "contact_phone",
+      "type": "link",
+      "required": 0,
+      "return_format": "array"
+    },
+    {
+      "key": "field_settings_contact_email",
+      "label": "Main Email",
+      "name": "contact_email",
+      "type": "link",
+      "required": 0,
+      "return_format": "array"
+    },
+    {
+      "key": "field_settings_main_address",
+      "label": "Main Address",
+      "name": "contact_main_address",
+      "type": "group",
+      "required": 0,
+      "sub_fields": [
+        {
+          "key": "field_settings_addr_street_number",
+          "label": "Street Number",
+          "name": "street_number",
+          "type": "text"
+        },
+        {
+          "key": "field_settings_addr_street_name",
+          "label": "Street Name",
+          "name": "street_name",
+          "type": "text"
+        },
+        {
+          "key": "field_settings_addr_city",
+          "label": "City",
+          "name": "city",
+          "type": "text"
+        },
+        {
+          "key": "field_settings_addr_state",
+          "label": "State",
+          "name": "state",
+          "type": "text"
+        },
+        {
+          "key": "field_settings_addr_post_code",
+          "label": "Postal Code",
+          "name": "post_code",
+          "type": "text"
+        },
+        {
+          "key": "field_settings_addr_lat",
+          "label": "Latitude",
+          "name": "lat",
+          "type": "text"
+        },
+        {
+          "key": "field_settings_addr_lng",
+          "label": "Longitude",
+          "name": "lng",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "key": "field_settings_offices",
+      "label": "Offices",
+      "name": "contact_offices",
+      "type": "repeater",
+      "required": 0,
+      "sub_fields": [
+        {
+          "key": "field_settings_office_name",
+          "label": "Office Name",
+          "name": "name",
+          "type": "text",
+          "required": 1
+        },
+        {
+          "key": "field_settings_office_address",
+          "label": "Address",
+          "name": "address",
+          "type": "textarea"
+        },
+        {
+          "key": "field_settings_office_phone",
+          "label": "Phone Number",
+          "name": "phone_number",
+          "type": "link",
+          "return_format": "array"
+        },
+        {
+          "key": "field_settings_office_directions",
+          "label": "Directions Link",
+          "name": "directions_link",
+          "type": "url"
+        }
+      ]
+    },
+    {
+      "key": "field_settings_social_profiles",
+      "label": "Social Profiles",
+      "name": "social_profiles",
+      "type": "repeater",
+      "instructions": "Links to social media profiles",
+      "required": 0,
+      "sub_fields": [
+        {
+          "key": "field_settings_social_url",
+          "label": "URL",
+          "name": "url",
+          "type": "url",
+          "required": 1
+        }
+      ]
+    },
+    {
+      "key": "field_settings_google_maps_key",
+      "label": "Google Maps API Key",
+      "name": "technical_google_maps_api_key",
+      "type": "text",
+      "required": 0
+    },
+    {
+      "key": "field_settings_schema_aggregate_rating",
+      "label": "Schema Aggregate Rating",
+      "name": "schema_aggregate_rating",
+      "type": "group",
+      "instructions": "Overall firm rating for schema markup",
+      "required": 0,
+      "sub_fields": [
+        {
+          "key": "field_settings_schema_rating_value",
+          "label": "Rating Value",
+          "name": "value",
+          "type": "number"
+        },
+        {
+          "key": "field_settings_schema_rating_count",
+          "label": "Review Count",
+          "name": "count",
+          "type": "number"
+        }
+      ]
+    },
+    {
+      "key": "field_settings_ask_question_form",
+      "label": "Ask a Question Form ID",
+      "name": "ask_a_question_form_id",
+      "type": "number",
+      "instructions": "Gravity Forms form ID for the 'Ask a Question' form",
+      "required": 0
+    }
+  ],
+  "location": [
+    [
+      {
+        "param": "options_page",
+        "operator": "==",
+        "value": "theme-general-settings"
+      }
+    ]
+  ],
+  "menu_order": 0,
+  "position": "normal",
+  "style": "default",
+  "label_placement": "top",
+  "instruction_placement": "label",
+  "hide_on_screen": "",
+  "active": true,
+  "description": ""
+}

--- a/challenge-2/theme/archive.php
+++ b/challenge-2/theme/archive.php
@@ -11,12 +11,10 @@ get_header();
 ?>
 	<div id="primary" class="content-area">
         <?php
-        $archive_template = 'archive';
-
-        if (is_post_type_archive('practice-area')) {
-            $archive_template = 'practice-area';
-        }
-        get_template_part( 'template-parts/archives/content', $archive_template);
+        $post_type = get_post_type();
+        $template = locate_template("template-parts/archives/content-{$post_type}.php");
+        $slug = $template ? $post_type : 'default';
+        get_template_part('template-parts/archives/content', $slug);
         ?>
 	</div><!-- #primary -->
 

--- a/challenge-2/theme/inc/cpt/all.php
+++ b/challenge-2/theme/inc/cpt/all.php
@@ -1,7 +1,6 @@
 <?php
 
-if (function_exists('pplf_register_post_types')) {
-    add_action('init', 'pplf_register_post_types', 10);
-} else {
+if (!function_exists('pplf_register_post_types')) {
     require_once WP_PLUGIN_DIR . '/pug-puggle-law-firm/inc/cpt/all.php';
+    add_action('init', 'pplf_register_post_types');
 }

--- a/challenge-2/theme/inc/cpt/all.php
+++ b/challenge-2/theme/inc/cpt/all.php
@@ -1,2 +1,7 @@
 <?php
 
+if (function_exists('pplf_register_post_types')) {
+    add_action('init', 'pplf_register_post_types', 10);
+} else {
+    require_once WP_PLUGIN_DIR . '/pug-puggle-law-firm/inc/cpt/all.php';
+}

--- a/challenge-2/theme/inc/hooks.php
+++ b/challenge-2/theme/inc/hooks.php
@@ -80,16 +80,6 @@ add_action('wp_footer', 'mp_output_additional_schema_for_post');
 
 ##-- MPD
 add_action('mpdcontent/ask-question/submission', function($data) {
-  GFAPI::add_entry(array(
-    '1' => $data['question'],
-    '4' => $data['name'],
-    '6' => $data['email'],
-    '7' => $data['content'],
-    'form_id'   => get_field('ask_a_question_form_id', 'option'),
-  ));
-});
-
-add_action('mpdcontent/ask-question/submission', function($data) {
   GFAPI::submit_form(
     get_field('ask_a_question_form_id', 'option'),
     array(

--- a/challenge-2/theme/inc/hooks.php
+++ b/challenge-2/theme/inc/hooks.php
@@ -46,6 +46,8 @@ function mp_output_default_schema_for_post() {
 
     if ( is_singular( 'office' ) ) {
         mp_generate_office_schema( $post );
+    } elseif ( is_singular( 'team' ) ) {
+        mp_generate_attorney_schema( $post );
     } else {
         mp_generate_local_business_schema();
     }
@@ -61,7 +63,7 @@ add_action('wp_footer', 'mp_output_default_schema_for_post');
 
 # outputs any additional for a post/page not covered by the default schema definitions
 function mp_output_additional_schema_for_post() {
-    if ( is_singular( array( 'post', 'practice-area' ) ) ) {
+    if ( is_singular( array( 'post', 'practice-area', 'local', 'office' ) ) ) {
         $faq_items = get_field('schema_faq_items');
 
         if ( $faq_items && sizeof( $faq_items ) > 0 ) {

--- a/challenge-2/theme/inc/tax/all.php
+++ b/challenge-2/theme/inc/tax/all.php
@@ -1,2 +1,7 @@
 <?php
 
+if (function_exists('pplf_register_taxonomies')) {
+    add_action('init', 'pplf_register_taxonomies', 10);
+} else {
+    require_once WP_PLUGIN_DIR . '/pug-puggle-law-firm/inc/tax/all.php';
+}

--- a/challenge-2/theme/inc/tax/all.php
+++ b/challenge-2/theme/inc/tax/all.php
@@ -1,7 +1,6 @@
 <?php
 
-if (function_exists('pplf_register_taxonomies')) {
-    add_action('init', 'pplf_register_taxonomies', 10);
-} else {
+if (!function_exists('pplf_register_taxonomies')) {
     require_once WP_PLUGIN_DIR . '/pug-puggle-law-firm/inc/tax/all.php';
+    add_action('init', 'pplf_register_taxonomies');
 }

--- a/challenge-2/theme/inc/utils/seo/schema.php
+++ b/challenge-2/theme/inc/utils/seo/schema.php
@@ -261,3 +261,51 @@ function mp_generate_faq_page_schema( $faq_markup, $comment = '' ) {
     echo json_encode( $schema );
     echo '</script>';
 }
+
+function mp_generate_attorney_schema($attorney) {
+    $position = get_field('position', $attorney);
+    $phone = get_field('phone', $attorney);
+    $email = get_field('email', $attorney);
+    $office = get_field('office', $attorney);
+
+    $schema = array(
+        '@context' => 'http://schema.org',
+        '@type' => 'Attorney',
+        'name' => get_the_title($attorney),
+        'description' => get_the_excerpt($attorney),
+        'image' => get_the_post_thumbnail_url($attorney, 'full'),
+        'telephone' => $phone,
+        'email' => $email,
+        'jobTitle' => $position,
+    );
+
+    if ($office) {
+        $office_address = get_field('address', $office);
+        $office_geopoint = get_field('geopoint', $office);
+
+        $schema['worksFor'] = array(
+            '@type' => 'LegalService',
+            'name' => get_bloginfo('name'),
+            'address' => array(
+                '@type' => 'PostalAddress',
+                'addressLocality' => $office_address['city'],
+                'addressRegion' => $office_address['state'],
+                'postalCode' => $office_address['postal_code'],
+                'streetAddress' => $office_address['street'] . ($office_address['street2'] ? ', ' . $office_address['street2'] : ''),
+            ),
+        );
+
+        if ($office_geopoint) {
+            $schema['worksFor']['geo'] = array(
+                '@type' => 'GeoCoordinates',
+                'latitude' => $office_geopoint['lat'],
+                'longitude' => $office_geopoint['lng'],
+            );
+        }
+    }
+
+    echo '<!-- SCHEMA: Attorney -->';
+    echo '<script type="application/ld+json">';
+    echo json_encode($schema);
+    echo '</script>';
+}

--- a/challenge-2/theme/plugins/pug-puggle-law-firm/inc/cpt/all.php
+++ b/challenge-2/theme/plugins/pug-puggle-law-firm/inc/cpt/all.php
@@ -1,0 +1,89 @@
+<?php
+
+function pplf_register_post_types() {
+    $post_types = array(
+        'practice-area' => array(
+            'label'               => __('Practice Areas', 'pug-puggle-law'),
+            'singular_name'       => __('Practice Area', 'pug-puggle-law'),
+            'description'         => __('Legal practice areas', 'pug-puggle-law'),
+            'public'              => true,
+            'hierarchical'        => true,
+            'has_archive'         => true,
+            'rewrite'             => array('slug' => 'practice-areas', 'with_front' => false),
+            'supports'            => array('title', 'editor', 'thumbnail', 'excerpt', 'page-attributes'),
+            'menu_icon'           => 'dashicons-portfolio',
+            'show_in_rest'        => true,
+        ),
+        'team' => array(
+            'label'               => __('Attorneys', 'pug-puggle-law'),
+            'singular_name'       => __('Attorney', 'pug-puggle-law'),
+            'description'         => __('Firm attorneys and staff', 'pug-puggle-law'),
+            'public'              => true,
+            'hierarchical'        => false,
+            'has_archive'         => true,
+            'rewrite'             => array('slug' => 'attorneys', 'with_front' => false),
+            'supports'            => array('title', 'editor', 'thumbnail', 'excerpt'),
+            'menu_icon'           => 'dashicons-groups',
+            'show_in_rest'        => true,
+        ),
+        'office' => array(
+            'label'               => __('Offices', 'pug-puggle-law'),
+            'singular_name'       => __('Office', 'pug-puggle-law'),
+            'description'         => __('Physical office locations', 'pug-puggle-law'),
+            'public'              => true,
+            'hierarchical'        => false,
+            'has_archive'         => true,
+            'rewrite'             => array('slug' => 'offices', 'with_front' => false),
+            'supports'            => array('title', 'editor', 'thumbnail'),
+            'menu_icon'           => 'dashicons-building',
+            'show_in_rest'        => true,
+        ),
+        'local' => array(
+            'label'               => __('Areas Served', 'pug-puggle-law'),
+            'singular_name'       => __('Area Served', 'pug-puggle-law'),
+            'description'         => __('Geographic areas the firm serves', 'pug-puggle-law'),
+            'public'              => true,
+            'hierarchical'        => true,
+            'has_archive'         => true,
+            'rewrite'             => array('slug' => 'locations', 'with_front' => false),
+            'supports'            => array('title', 'editor', 'page-attributes'),
+            'menu_icon'           => 'dashicons-location',
+            'show_in_rest'        => true,
+        ),
+        'testimonials' => array(
+            'label'               => __('Testimonials', 'pug-puggle-law'),
+            'singular_name'       => __('Testimonial', 'pug-puggle-law'),
+            'description'         => __('Client reviews and case results', 'pug-puggle-law'),
+            'public'              => true,
+            'hierarchical'        => false,
+            'has_archive'         => true,
+            'rewrite'             => array('slug' => 'testimonials', 'with_front' => false),
+            'supports'            => array('title', 'editor'),
+            'menu_icon'           => 'dashicons-star-filled',
+            'show_in_rest'        => true,
+        ),
+    );
+
+    foreach ($post_types as $slug => $args) {
+        $defaults = array(
+            'labels'              => array(
+                'name'          => $args['label'],
+                'singular_name' => $args['singular_name'],
+                'add_new_item'  => sprintf(__('Add New %s', 'pug-puggle-law'), $args['singular_name']),
+                'edit_item'     => sprintf(__('Edit %s', 'pug-puggle-law'), $args['singular_name']),
+                'view_item'     => sprintf(__('View %s', 'pug-puggle-law'), $args['singular_name']),
+                'search_items'  => sprintf(__('Search %s', 'pug-puggle-law'), $args['label']),
+                'not_found'     => sprintf(__('No %s found', 'pug-puggle-law'), $args['label']),
+            ),
+            'public'              => true,
+            'hierarchical'        => false,
+            'has_archive'         => true,
+            'show_in_rest'        => true,
+            'supports'            => array('title', 'editor'),
+            'menu_position'       => 20,
+        );
+
+        register_post_type($slug, wp_parse_args($args, $defaults));
+    }
+}
+add_action('init', 'pplf_register_post_types');

--- a/challenge-2/theme/plugins/pug-puggle-law-firm/inc/tax/all.php
+++ b/challenge-2/theme/plugins/pug-puggle-law-firm/inc/tax/all.php
@@ -1,0 +1,39 @@
+<?php
+
+function pplf_register_taxonomies() {
+    $taxonomies = array(
+        'area-served' => array(
+            'label'             => __('Areas Served', 'pug-puggle-law'),
+            'singular_name'     => __('Area Served', 'pug-puggle-law'),
+            'hierarchical'      => true,
+            'rewrite'           => array('slug' => 'area-served', 'with_front' => false),
+            'show_in_rest'      => true,
+            'post_types'        => array('practice-area', 'local', 'office'),
+        ),
+    );
+
+    foreach ($taxonomies as $slug => $args) {
+        $post_types = $args['post_types'];
+        unset($args['post_types']);
+
+        $defaults = array(
+            'labels' => array(
+                'name'          => $args['label'],
+                'singular_name' => $args['singular_name'],
+                'add_new_item'  => sprintf(__('Add New %s', 'pug-puggle-law'), $args['singular_name']),
+                'edit_item'     => sprintf(__('Edit %s', 'pug-puggle-law'), $args['singular_name']),
+                'search_items'  => sprintf(__('Search %s', 'pug-puggle-law'), $args['label']),
+            ),
+            'show_in_rest' => true,
+        );
+
+        register_taxonomy($slug, $post_types, wp_parse_args($args, $defaults));
+    }
+}
+add_action('init', 'pplf_register_taxonomies');
+
+function pplf_flush_rewrites() {
+    pplf_register_post_types();
+    pplf_register_taxonomies();
+    flush_rewrite_rules();
+}

--- a/challenge-2/theme/plugins/pug-puggle-law-firm/pug-puggle-law-firm.php
+++ b/challenge-2/theme/plugins/pug-puggle-law-firm/pug-puggle-law-firm.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Pug & Puggle Law Firm
+ * Description: Custom post types, taxonomies, and field groups for the Pug & Puggle, ESQ law firm website.
+ * Version: 1.0.0
+ * Author: MeanPug Digital
+ * Text Domain: pug-puggle-law
+ */
+
+define('PPLF_VERSION', '1.0.0');
+define('PPLF_PLUGIN_DIR', plugin_dir_path(__FILE__));
+
+require_once PPLF_PLUGIN_DIR . 'inc/cpt/all.php';
+require_once PPLF_PLUGIN_DIR . 'inc/tax/all.php';
+
+register_activation_hook(__FILE__, 'pplf_flush_rewrites');

--- a/challenge-2/theme/plugins/pug-puggle-law-firm/pug-puggle-law-firm.php
+++ b/challenge-2/theme/plugins/pug-puggle-law-firm/pug-puggle-law-firm.php
@@ -14,3 +14,4 @@ require_once PPLF_PLUGIN_DIR . 'inc/cpt/all.php';
 require_once PPLF_PLUGIN_DIR . 'inc/tax/all.php';
 
 register_activation_hook(__FILE__, 'pplf_flush_rewrites');
+register_deactivation_hook(__FILE__, 'flush_rewrite_rules');

--- a/challenge-2/theme/template-parts/archives/content-default.php
+++ b/challenge-2/theme/template-parts/archives/content-default.php
@@ -1,0 +1,23 @@
+<?php
+?>
+<main class="inf-archive inf-archive-<?php echo esc_attr(get_post_type()); ?>">
+    <header class="page-header">
+        <?php
+        the_archive_title('<h1 class="page-title">', '</h1>');
+        the_archive_description('<div class="archive-description">', '</div>');
+        ?>
+    </header>
+
+    <?php while (have_posts()) : the_post(); ?>
+    <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+        <a href="<?php the_permalink(); ?>">
+            <h2><?php the_title(); ?></h2>
+        </a>
+        <div class="entry-summary">
+            <?php the_excerpt(); ?>
+        </div>
+    </article>
+    <?php endwhile; ?>
+
+    <?php the_posts_navigation(); ?>
+</main>

--- a/challenge-2/theme/template-parts/archives/content-practice-area.php
+++ b/challenge-2/theme/template-parts/archives/content-practice-area.php
@@ -1,7 +1,17 @@
-<?php
-?>
 <main class="inf-archive inf-practice-areas">
     <?php while (have_posts()) : the_post(); ?>
-    <!-- STUFF HERE -->
+    <article id="post-<?php the_ID(); ?>" <?php post_class('practice-area-card'); ?>>
+        <?php if (has_post_thumbnail()) : ?>
+        <div class="practice-area-image">
+            <a href="<?php the_permalink(); ?>"><?php the_post_thumbnail('medium'); ?></a>
+        </div>
+        <?php endif; ?>
+        <div class="practice-area-content">
+            <h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+            <div class="practice-area-excerpt"><?php the_excerpt(); ?></div>
+            <a href="<?php the_permalink(); ?>" class="button">Learn More</a>
+        </div>
+    </article>
     <?php endwhile; ?>
+    <?php the_posts_pagination(); ?>
 </main>

--- a/challenge-2/theme/template-parts/content-front-page.php
+++ b/challenge-2/theme/template-parts/content-front-page.php
@@ -1,2 +1,5 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+    <div class="entry-content Content Content--main">
+        <?php the_content(); ?>
+    </div>
 </article>

--- a/challenge-2/theme/template-parts/headers/content-default-header.php
+++ b/challenge-2/theme/template-parts/headers/content-default-header.php
@@ -1,0 +1,10 @@
+<?php
+$subtitle = get_field('page_subtitle') ?: '';
+?>
+<header class="page-header">
+    <?php if (function_exists('rank_math_the_breadcrumbs')) rank_math_the_breadcrumbs(); ?>
+    <h1 class="page-title"><?php the_title(); ?></h1>
+    <?php if ($subtitle) : ?>
+    <p class="page-subtitle"><?php echo esc_html($subtitle); ?></p>
+    <?php endif; ?>
+</header>


### PR DESCRIPTION
## Summary

Backend implementation for "Pug & Puggle, ESQ" law firm website.

- **Custom Plugin** — `pug-puggle-law-firm` with 5 CPTs (practice-area, team, office, local, testimonials) and 1 taxonomy (area-served), all show_in_rest
- **ACF Field Groups** — 6 JSON files synced via Local JSON for all content types + global theme settings
- **Schema.org** — 8 types: Attorney, LocalBusiness, LegalService, Product, Review, AggregateRating, FAQPage, Question/Answer
- **Geo/Location** — Haversine distance search, Google Maps SDK, location-aware AJAX search
- **Modular Architecture** — Plugin separated from theme with function_exists delegation, module base class, widget system
- **Template Updates** — Archive routes all 5 CPTs with fallback, single.php handles all CPTs

## Test Plan
- [x] Docker compose stack boots without errors
- [x] Webpack build succeeds on npm run dev
- [x] Plugin activates and registers all CPTs/taxonomies
- [x] ACF field groups sync from Local JSON
- [x] Schema.org output renders on all CPT singles
- [x] Archive template handles all 5 CPTs with fallback