### PR TITLE
MeanPug WordPress Developer Challenge - Pugsly-Para

### DIFF
--- a/challenge-2/theme/inc/cpt/all.php
+++ b/challenge-2/theme/inc/cpt/all.php
@@ -1,2 +1,166 @@
 <?php
 
+function inf_register_custom_post_types() {
+
+    // Practice Areas (hierarchical to support child topics)
+    register_post_type('practice-area', array(
+        'labels' => array(
+            'name'               => 'Practice Areas',
+            'singular_name'      => 'Practice Area',
+            'add_new_item'       => 'Add New Practice Area',
+            'edit_item'          => 'Edit Practice Area',
+            'view_item'          => 'View Practice Area',
+            'search_items'       => 'Search Practice Areas',
+            'not_found'          => 'No Practice Areas found',
+        ),
+        'public'            => true,
+        'hierarchical'      => true,
+        'has_archive'       => true,
+        'rewrite'           => array('slug' => 'practice-areas'),
+        'menu_icon'         => 'dashicons-clipboard',
+        'supports'          => array('title', 'editor', 'thumbnail', 'excerpt', 'page-attributes'),
+        'show_in_rest'      => true,
+    ));
+
+    // Team (Attorneys)
+    register_post_type('team', array(
+        'labels' => array(
+            'name'               => 'Attorneys',
+            'singular_name'      => 'Attorney',
+            'add_new_item'       => 'Add New Attorney',
+            'edit_item'          => 'Edit Attorney',
+            'view_item'          => 'View Attorney',
+            'search_items'       => 'Search Attorneys',
+            'not_found'          => 'No Attorneys found',
+        ),
+        'public'            => true,
+        'hierarchical'      => false,
+        'has_archive'       => true,
+        'rewrite'           => array('slug' => 'attorneys'),
+        'menu_icon'         => 'dashicons-businessperson',
+        'supports'          => array('title', 'editor', 'thumbnail', 'author'),
+        'show_in_rest'      => true,
+    ));
+
+    // Offices
+    register_post_type('office', array(
+        'labels' => array(
+            'name'               => 'Offices',
+            'singular_name'      => 'Office',
+            'add_new_item'       => 'Add New Office',
+            'edit_item'          => 'Edit Office',
+            'view_item'          => 'View Office',
+            'search_items'       => 'Search Offices',
+            'not_found'          => 'No Offices found',
+        ),
+        'public'            => true,
+        'hierarchical'      => false,
+        'has_archive'       => true,
+        'rewrite'           => array('slug' => 'offices'),
+        'menu_icon'         => 'dashicons-location',
+        'supports'          => array('title', 'editor', 'thumbnail'),
+        'show_in_rest'      => true,
+    ));
+
+    // Testimonials
+    register_post_type('testimonials', array(
+        'labels' => array(
+            'name'               => 'Testimonials',
+            'singular_name'      => 'Testimonial',
+            'add_new_item'       => 'Add New Testimonial',
+            'edit_item'          => 'Edit Testimonial',
+            'view_item'          => 'View Testimonial',
+            'search_items'       => 'Search Testimonials',
+            'not_found'          => 'No Testimonials found',
+        ),
+        'public'            => true,
+        'hierarchical'      => false,
+        'has_archive'       => true,
+        'rewrite'           => array('slug' => 'testimonials'),
+        'menu_icon'         => 'dashicons-format-quote',
+        'supports'          => array('title', 'editor'),
+        'show_in_rest'      => true,
+    ));
+
+    // Local (Area Served pages — supports parent/child hierarchy for state > city grouping)
+    register_post_type('local', array(
+        'labels' => array(
+            'name'               => 'Local Pages',
+            'singular_name'      => 'Local Page',
+            'add_new_item'       => 'Add New Local Page',
+            'edit_item'          => 'Edit Local Page',
+            'view_item'          => 'View Local Page',
+            'search_items'       => 'Search Local Pages',
+            'not_found'          => 'No Local Pages found',
+        ),
+        'public'            => true,
+        'hierarchical'      => true,
+        'has_archive'       => true,
+        'rewrite'           => array('slug' => 'locations'),
+        'menu_icon'         => 'dashicons-admin-site',
+        'supports'          => array('title', 'editor', 'thumbnail', 'excerpt', 'page-attributes'),
+        'show_in_rest'      => true,
+    ));
+
+    // Case Results / Verdicts
+    register_post_type('case-result', array(
+        'labels' => array(
+            'name'               => 'Case Results',
+            'singular_name'      => 'Case Result',
+            'add_new_item'       => 'Add New Case Result',
+            'edit_item'          => 'Edit Case Result',
+            'view_item'          => 'View Case Result',
+            'search_items'       => 'Search Case Results',
+            'not_found'          => 'No Case Results found',
+        ),
+        'public'            => true,
+        'hierarchical'      => false,
+        'has_archive'       => true,
+        'rewrite'           => array('slug' => 'case-results'),
+        'menu_icon'         => 'dashicons-awards',
+        'supports'          => array('title', 'editor'),
+        'show_in_rest'      => true,
+    ));
+
+    // FAQs
+    register_post_type('faq', array(
+        'labels' => array(
+            'name'               => 'FAQs',
+            'singular_name'      => 'FAQ',
+            'add_new_item'       => 'Add New FAQ',
+            'edit_item'          => 'Edit FAQ',
+            'view_item'          => 'View FAQ',
+            'search_items'       => 'Search FAQs',
+            'not_found'          => 'No FAQs found',
+        ),
+        'public'            => true,
+        'hierarchical'      => false,
+        'has_archive'       => true,
+        'rewrite'           => array('slug' => 'faqs'),
+        'menu_icon'         => 'dashicons-editor-help',
+        'supports'          => array('title', 'editor'),
+        'show_in_rest'      => true,
+    ));
+
+    // Awards
+    register_post_type('award', array(
+        'labels' => array(
+            'name'               => 'Awards',
+            'singular_name'      => 'Award',
+            'add_new_item'       => 'Add New Award',
+            'edit_item'          => 'Edit Award',
+            'view_item'          => 'View Award',
+            'search_items'       => 'Search Awards',
+            'not_found'          => 'No Awards found',
+        ),
+        'public'            => true,
+        'hierarchical'      => false,
+        'has_archive'       => true,
+        'rewrite'           => array('slug' => 'awards'),
+        'menu_icon'         => 'dashicons-star-filled',
+        'supports'          => array('title', 'editor', 'thumbnail'),
+        'show_in_rest'      => true,
+    ));
+
+}
+add_action('init', 'inf_register_custom_post_types');

--- a/challenge-2/theme/inc/tax/all.php
+++ b/challenge-2/theme/inc/tax/all.php
@@ -1,2 +1,67 @@
 <?php
 
+function inf_register_taxonomies() {
+
+    // Practice Area Type
+    // Shared across team, local, and testimonials for cross-referencing content
+    register_taxonomy('practice-area-type', array('team', 'local', 'testimonials', 'case-result', 'faq'), array(
+        'labels' => array(
+            'name'              => 'Practice Area Types',
+            'singular_name'     => 'Practice Area Type',
+            'search_items'      => 'Search Practice Area Types',
+            'all_items'         => 'All Practice Area Types',
+            'edit_item'         => 'Edit Practice Area Type',
+            'update_item'       => 'Update Practice Area Type',
+            'add_new_item'      => 'Add New Practice Area Type',
+            'new_item_name'     => 'New Practice Area Type',
+            'menu_name'         => 'Practice Area Types',
+        ),
+        'hierarchical'      => true,
+        'public'            => true,
+        'show_in_rest'      => true,
+        'rewrite'           => array('slug' => 'practice-area-type'),
+    ));
+
+    // Area Served
+    // Geographic taxonomy linking local pages to practice areas
+    // Referenced in location navigator widget and services/locations.php queries
+    register_taxonomy('area-served', array('local', 'practice-area'), array(
+        'labels' => array(
+            'name'              => 'Areas Served',
+            'singular_name'     => 'Area Served',
+            'search_items'      => 'Search Areas Served',
+            'all_items'         => 'All Areas Served',
+            'edit_item'         => 'Edit Area Served',
+            'update_item'       => 'Update Area Served',
+            'add_new_item'      => 'Add New Area Served',
+            'new_item_name'     => 'New Area Served',
+            'menu_name'         => 'Areas Served',
+        ),
+        'hierarchical'      => true,
+        'public'            => true,
+        'show_in_rest'      => true,
+        'rewrite'           => array('slug' => 'area-served'),
+    ));
+
+    // Case Type
+    // Used for categorizing case results and filtering by injury type
+    register_taxonomy('case-type', array('post'), array(
+        'labels' => array(
+            'name'              => 'Case Types',
+            'singular_name'     => 'Case Type',
+            'search_items'      => 'Search Case Types',
+            'all_items'         => 'All Case Types',
+            'edit_item'         => 'Edit Case Type',
+            'update_item'       => 'Update Case Type',
+            'add_new_item'      => 'Add New Case Type',
+            'new_item_name'     => 'New Case Type',
+            'menu_name'         => 'Case Types',
+        ),
+        'hierarchical'      => true,
+        'public'            => true,
+        'show_in_rest'      => true,
+        'rewrite'           => array('slug' => 'case-type'),
+    ));
+
+}
+add_action('init', 'inf_register_taxonomies');


### PR DESCRIPTION
MeanPug WordPress Developer Challenge

Challenge 1: Pugify That Site

Replicated the Airbnb homepage above-the-fold design in WordPress using Elementor Pro. 

The layout includes:
- Announcement bar, header with nav, and tab row
- Search bar built with a flex container, column borders as dividers, and a styled button using Font Awesome's search icon
- Full-width hero section with left-aligned text overlay
- Three-column image row below the hero
- MeanPug pug placed as the profile avatar in the header nav



Challenge 2: Nothing's Sexier Than a Solid Schema

Before writing any code I read through the existing theme architecture (functions.php, hooks.php, schema.php, locations.php, etc, to understand what content types and field names the theme was already expecting. 
This shaped the decisions that followed.

Registered in code so definitions are version-controlled and portable:

CPT | Slug | Notes
-- | -- | --
Practice Areas | practice-area | Hierarchical - supports child topic pages per snippets/content-topics-accordion.php
Attorneys | team | Slug confirmed via template_functions.php canonical map and widget queries
Offices | office | Referenced in hooks.php mp_generate_office_schema()
Testimonials | testimonials | Referenced in hooks, schema functions, and PPC landing page template
Local Pages | local | Hierarchical for state > city grouping per location navigator widget
Case Results | case-result | Prominent on both Morgan & Morgan and Milberg reference sites
FAQs | faq | Supports firm-wide FAQs beyond the per-practice-area schema_faq_items repeater
Awards | award | Referenced in PPC landing page template awards carousel


Taxonomy | Slug | Applied To
-- | -- | --
Practice Area Type | practice-area-type | team, local, testimonials, case-result, faq
Area Served | area-served | local, practice-area - referenced in location navigator widget queries
Case Type | case-type | post


ACF Field Groups

Built field groups for all CPTs with field names matching exactly what the existing theme code calls via get_field():

- Testimonials - reviewer (group > name), rating
- Office - address (group > street, street2, city, state, postal_code), geopoint
- Team - role, email, phone (link), headshot
- Local - geopoint, content_type (select: Area Served/Landing Page), practice_areas (relationship)
- Practice Areas - testimonials (relationship), schema_faq_items (group > question, answer)
- Case Results - settlement_amount, case_type, case_description, case_date, practice_areas
- FAQ - question, answer, practice_areas (relationship)
- Awards - image, year, issuing_organization
- Theme Options - contact_phone, contact_email, contact_main_address, social_profiles, schema_aggregate_rating, ask_a_question_form_id

ACF PRO Notes

Two field types in this implementation require ACF PRO:

- schema_faq_items on Practice Areas — implemented as a Group in free ACF. 
  - In production this should be a Repeater to support multiple FAQ items per practice area, as the existing mp_output_additional_schema_for_post() in hooks.php loops over this field expecting multiple rows.

- social_profiles on the Options Page — same situation, implemented as a Group, should be a Repeater in production.

Options Page itself requires ACF PRO — the page registration is already scaffolded in inc/settings/all.php, field group is ready to activate once PRO is in place.


Plugins Installed

- Advanced Custom Fields (free)
- Yoast SEO
- Gravity Forms — noted as a dependency per hooks.php GFAPI references, requires license
- Max Mega Menu


Named the branch Pugsly-Para. Pugsly felt right. Sorry, not sorry.


